### PR TITLE
ViewControllerとViewModelをRxに書き換え

### DIFF
--- a/CTAProject/Error/APIError.swift
+++ b/CTAProject/Error/APIError.swift
@@ -10,4 +10,5 @@ import Foundation
 enum APIError: Error {
     case textEncodingError
     case decodeError
+    case unexpectedError
 }

--- a/CTAProject/Extension/HUDContentType+Extension.swift
+++ b/CTAProject/Extension/HUDContentType+Extension.swift
@@ -1,0 +1,94 @@
+//
+//  HUDContentType+Extension.swift
+//  CTAProject
+//
+//  Created by 内山和輝 on 2022/03/08.
+//
+
+import Foundation
+import PKHUD
+
+extension HUDContentType: Equatable {
+    public static func == (lhs: HUDContentType, rhs: HUDContentType) -> Bool {
+        switch lhs {
+        case .success:
+            if case .success = rhs {
+                return true
+            } else {
+                return false
+            }
+        case .error:
+            if case .error = rhs {
+                return true
+            } else {
+                return false
+            }
+        case .progress:
+            if case .progress = rhs {
+                return true
+            } else {
+                return false
+            }
+        case .image:
+            if case .image = rhs {
+                return true
+            } else {
+                return false
+            }
+        case .rotatingImage:
+            if case .rotatingImage = rhs {
+                return true
+            } else {
+                return false
+            }
+        case .labeledSuccess:
+            if case .labeledSuccess = rhs {
+                return true
+            } else {
+                return false
+            }
+        case .labeledError:
+            if case .labeledError = rhs {
+                return true
+            } else {
+                return false
+            }
+        case .labeledProgress:
+            if case .labeledProgress = rhs {
+                return true
+            } else {
+                return false
+            }
+        case .labeledImage:
+            if case .labeledImage = rhs {
+                return true
+            } else {
+                return false
+            }
+        case .labeledRotatingImage:
+            if case .labeledRotatingImage = rhs {
+                return true
+            } else {
+                return false
+            }
+        case .label:
+            if case .label = rhs {
+                return true
+            } else {
+                return false
+            }
+        case .systemActivity:
+            if case .systemActivity = rhs {
+                return true
+            } else {
+                return false
+            }
+        case .customView:
+            if case .customView = rhs {
+                return true
+            } else {
+                return false
+            }
+        }
+    }
+}

--- a/CTAProject/Extension/RelayWrapper.swift
+++ b/CTAProject/Extension/RelayWrapper.swift
@@ -1,0 +1,75 @@
+//
+//  RelayWrapper.swift
+//  CTAProject
+//
+//  Created by 内山和輝 on 2022/02/24.
+//
+
+import Foundation
+import RxSwift
+import RxCocoa
+
+@propertyWrapper
+struct BehaviorRelayWrapper<T> {
+    private let relay: BehaviorRelay<T>
+    private let observable: Observable<T>
+    init(value: T) {
+        relay = BehaviorRelay(value: value)
+        observable = relay.asObservable()
+    }
+    var wrappedValue: Observable<T> {
+        observable
+    }
+    var projectedValue: BehaviorRelay<T> {
+        relay
+    }
+}
+
+@propertyWrapper
+struct PublishRelayWrapper<T> {
+    private let relay: PublishRelay<T>
+    private let observable: Observable<T>
+    init() {
+        relay = PublishRelay<T>()
+        observable = relay.asObservable()
+    }
+    var wrappedValue: Observable<T> {
+        observable
+    }
+    var projectedValue: PublishRelay<T> {
+        relay
+    }
+}
+
+@propertyWrapper
+struct AnyObserverWrapper<T> {
+    private let relay = PublishRelay<T>()
+    private let observer: AnyObserver<T>
+    private let observable: Observable<T>
+    init() {
+        observer = .create(relay)
+        observable = relay.asObservable()
+    }
+    var wrappedValue: AnyObserver<T> {
+        observer
+    }
+    var projectedValue: Observable<T> {
+        observable
+    }
+}
+
+extension AnyObserver {
+    static func create<E>(_ relay: PublishRelay<E>) -> AnyObserver<E> {
+        return .init { event in
+            guard case let .next(value) = event else { return }
+            relay.accept(value)
+        }
+    }
+
+    static func create<E>(_ relay: BehaviorRelay<E>) -> AnyObserver<E> {
+        return .init { event in
+            guard case let .next(value) = event else { return }
+            relay.accept(value)
+        }
+    }
+}

--- a/CTAProject/Repository/APIClient.swift
+++ b/CTAProject/Repository/APIClient.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-enum APIClient {
-    static func searchShop(searchWord: String, completion: @escaping(Result<HotPepper, APIError>) -> Void )  {
+final class APIClient: HotPepperAPIType {
+    func searchShop(searchWord: String, completion: @escaping(Result<HotPepper, APIError>) -> Void )  {
         let encodedSearchWord = searchWord.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)
         
         //別ファイルからAPIキー読み込み

--- a/CTAProject/Repository/APIClient.swift
+++ b/CTAProject/Repository/APIClient.swift
@@ -6,36 +6,41 @@
 //
 
 import Foundation
+import RxSwift
 
 final class APIClient: HotPepperAPIType {
-    func searchShop(searchWord: String, completion: @escaping(Result<HotPepper, APIError>) -> Void )  {
+    func searchShop(searchWord: String) -> Single<HotPepper> {
         let encodedSearchWord = searchWord.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)
-        
-        //別ファイルからAPIキー読み込み
-        let APIKey = MyAPIKey.hotpepper
-        guard let url = URL(string: "https://webservice.recruit.co.jp/hotpepper/gourmet/v1/?key=" + APIKey + "&format=json&keyword=" + String(encodedSearchWord!)) else { return completion(.failure(.textEncodingError)) }
-        
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        
-        let task = URLSession.shared.dataTask(with: url) { (data, responds, error) in
-            if let error = error {
-                print("情報の取得に失敗しました。:", error)
-                return
+        return Single<HotPepper>.create { observer in
+            let APIKey = MyAPIKey.hotpepper
+            guard let url = URL(string: "https://webservice.recruit.co.jp/hotpepper/gourmet/v1/?key=" + APIKey + "&format=json&keyword=" + String(encodedSearchWord!)) else {
+                observer(.failure(APIError.textEncodingError))
+                return Disposables.create()
             }
             
-            if let data = data {
-                do {
-                    let hotpepper = try JSONDecoder().decode(HotPepper.self, from: data)
-                    completion(.success(hotpepper))
-                    print("json:", hotpepper)
-                } catch {
-                    completion(.failure(.decodeError))
-                    print("デコードに失敗しました。:", error)
+            var request = URLRequest(url: url)
+            request.httpMethod = "GET"
+            
+            let task = URLSession.shared.dataTask(with: url) { (data, _, error) in
+                if let error = error {
+                    print("情報の取得に失敗しました。:", error)
+                    observer(.failure(APIError.unexpectedError))
+                    return
+                }
+                
+                if let data = data {
+                    do {
+                        let hotpepper = try JSONDecoder().decode(HotPepper.self, from: data)
+                        observer(.success(hotpepper))
+                        print("json:", hotpepper)
+                    } catch {
+                        observer(.failure(APIError.decodeError))
+                        print("デコードに失敗しました。:", error)
+                    }
                 }
             }
+            task.resume()
+            return Disposables.create()
         }
-        task.resume()
-        return
     }
 }

--- a/CTAProject/Repository/APIClient.swift
+++ b/CTAProject/Repository/APIClient.swift
@@ -13,7 +13,7 @@ final class APIClient: HotPepperAPIType {
         let encodedSearchWord = searchWord.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)
         return Single<HotPepper>.create { observer in
             let APIKey = MyAPIKey.hotpepper
-            guard let url = URL(string: "https://webservice.recruit.co.jp/hotpepper/gourmet/v1/?key=" + APIKey + "&format=json&keyword=" + String(encodedSearchWord!)) else {
+            guard let url = URL(string: "https://webservice.recruit.co.jp/hotpepper/gourmet/v1/?key=\(APIKey)&format=json&keyword=\(encodedSearchWord!)") else {
                 observer(.failure(APIError.textEncodingError))
                 return Disposables.create()
             }

--- a/CTAProject/Repository/HotPepperAPIInterface.swift
+++ b/CTAProject/Repository/HotPepperAPIInterface.swift
@@ -1,0 +1,12 @@
+//
+//  HotPepperAPIInterface.swift
+//  CTAProject
+//
+//  Created by 内山和輝 on 2022/03/01.
+//
+
+import Foundation
+
+protocol HotPepperAPIType {
+    func searchShop(searchWord: String, completion: @escaping(Result<HotPepper, APIError>) -> Void )
+}

--- a/CTAProject/Repository/HotPepperAPIInterface.swift
+++ b/CTAProject/Repository/HotPepperAPIInterface.swift
@@ -6,7 +6,8 @@
 //
 
 import Foundation
+import RxSwift
 
 protocol HotPepperAPIType {
-    func searchShop(searchWord: String, completion: @escaping(Result<HotPepper, APIError>) -> Void )
+    func searchShop(searchWord: String) -> Single<HotPepper>
 }

--- a/CTAProject/UIComponent/ViewController/SearchShopViewController.swift
+++ b/CTAProject/UIComponent/ViewController/SearchShopViewController.swift
@@ -36,8 +36,6 @@ final class SearchShopViewController: UIViewController {
         tabBar.tintColor = .systemYellow
         
         shopTableView.register(ShopTableViewCell.nib, forCellReuseIdentifier: ShopTableViewCell.identifier)
-        self.shopTableView.delegate = nil
-        self.shopTableView.dataSource = nil
         
         searchShopBar.rx.searchButtonClicked
             .bind(to: searchShopViewModel.inputs.searchBarSearchButtonClicked)
@@ -100,23 +98,6 @@ final class SearchShopViewController: UIViewController {
     }
     */
 
-}
-
-// MARK: TableViewDelegate
-extension SearchShopViewController: UITableViewDelegate {
-}
-
-// MARK: TableViewDataSource
-extension SearchShopViewController: UITableViewDataSource {
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return shops.count
-    }
-    
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: ShopTableViewCell.identifier, for: indexPath) as! ShopTableViewCell
-        cell.configureCell(shop: shops[indexPath.row])
-        return cell
-    }
 }
 
 extension SearchShopViewController: UISearchBarDelegate {

--- a/CTAProject/UIComponent/ViewController/SearchShopViewController.swift
+++ b/CTAProject/UIComponent/ViewController/SearchShopViewController.swift
@@ -69,7 +69,13 @@ final class SearchShopViewController: UIViewController {
         searchShopViewModel.outputs.showPopup
             .subscribe(onNext: {
                 let popupView = MessageView.viewFromNib(layout: .cardView)
-                SwiftMessages.show(view: popupView)
+                popupView.configureTheme(.warning)
+                popupView.configureContent(title: L10n.noCharactersInput, body: "")
+                popupView.button?.isHidden = true
+                popupView.backgroundView.backgroundColor = .systemYellow
+                var config = SwiftMessages.Config()
+                config.presentationStyle = .center
+                SwiftMessages.show(config: config, view: popupView)
             })
             .disposed(by: disposeBag)
         
@@ -115,20 +121,5 @@ extension SearchShopViewController: UITableViewDataSource {
 extension SearchShopViewController: UISearchBarDelegate {
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         searchShopBar.resignFirstResponder()
-        guard let searchWord = searchShopBar.text else { return }
-        //0字でポップアップ表示、50文字以上でアラート表示
-        if searchWord.count == 0 {
-//            let popupView = MessageView.viewFromNib(layout: .cardView)
-//            popupView.configureTheme(.warning)
-//            popupView.configureContent(title: L10n.noCharactersInput, body: "")
-//            popupView.button?.isHidden = true
-//            popupView.backgroundView.backgroundColor = .systemYellow
-//            var config = SwiftMessages.Config()
-//            config.presentationStyle = .center
-//            SwiftMessages.show(config: config, view: popupView)
-        } else if searchWord.count >= 50 {
-//            let alertView = AlertView.nib.instantiate(withOwner: self, options: nil)[0] as! UIView
-//            view.addSubview(alertView)
-        }
     }
 }

--- a/CTAProject/UIComponent/ViewController/SearchShopViewController.swift
+++ b/CTAProject/UIComponent/ViewController/SearchShopViewController.swift
@@ -40,8 +40,11 @@ final class SearchShopViewController: UIViewController {
         shopTableView.dataSource = self
         
         searchShopBar.rx.searchButtonClicked
-            .withLatestFrom(searchShopBar.rx.text.orEmpty)
             .bind(to: searchShopViewModel.inputs.searchBarSearchButtonClicked)
+            .disposed(by: disposeBag)
+        
+        searchShopBar.rx.text.orEmpty
+            .bind(to: searchShopViewModel.inputs.searchTextInput)
             .disposed(by: disposeBag)
         
         searchShopViewModel.outputs.shopData

--- a/CTAProject/UIComponent/ViewController/SearchShopViewController.swift
+++ b/CTAProject/UIComponent/ViewController/SearchShopViewController.swift
@@ -67,7 +67,7 @@ final class SearchShopViewController: UIViewController {
             .disposed(by: disposeBag)
         
         searchShopViewModel.outputs.showPopup
-            .subscribe(onNext: {
+            .subscribe(onNext: { _ in
                 let popupView = MessageView.viewFromNib(layout: .cardView)
                 popupView.configureTheme(.warning)
                 popupView.configureContent(title: L10n.noCharactersInput, body: "")

--- a/CTAProject/UIComponent/ViewController/SearchShopViewController.swift
+++ b/CTAProject/UIComponent/ViewController/SearchShopViewController.swift
@@ -59,7 +59,6 @@ final class SearchShopViewController: UIViewController {
             .disposed(by: disposeBag)
         
         searchShopViewModel.outputs.hudHide
-            .observe(on: MainScheduler.instance)
             .subscribe(onNext: { _ in
                 HUD.hide()
             })

--- a/CTAProject/UIComponent/ViewController/SearchShopViewController.swift
+++ b/CTAProject/UIComponent/ViewController/SearchShopViewController.swift
@@ -36,8 +36,8 @@ final class SearchShopViewController: UIViewController {
         tabBar.tintColor = .systemYellow
         
         shopTableView.register(ShopTableViewCell.nib, forCellReuseIdentifier: ShopTableViewCell.identifier)
-        shopTableView.delegate = self
-        shopTableView.dataSource = self
+        self.shopTableView.delegate = nil
+        self.shopTableView.dataSource = nil
         
         searchShopBar.rx.searchButtonClicked
             .bind(to: searchShopViewModel.inputs.searchBarSearchButtonClicked)
@@ -48,12 +48,10 @@ final class SearchShopViewController: UIViewController {
             .disposed(by: disposeBag)
         
         searchShopViewModel.outputs.shopData
-            .withUnretained(self)
-            .observe(on: MainScheduler.instance)
-            .subscribe(onNext: { me, shopData in
-                me.shops = shopData
-                me.shopTableView.reloadData()
-            })
+            .bind(to: shopTableView.rx.items(cellIdentifier: ShopTableViewCell.identifier, cellType: ShopTableViewCell.self)) {
+                _, shops, cell in
+                cell.configureCell(shop: shops)
+            }
             .disposed(by: disposeBag)
         
         searchShopViewModel.outputs.hudShow

--- a/CTAProject/UIComponent/ViewController/SearchShopViewController.swift
+++ b/CTAProject/UIComponent/ViewController/SearchShopViewController.swift
@@ -22,7 +22,7 @@ final class SearchShopViewController: UIViewController {
     
     private var shops: [Shop] = []
     
-    private let searchShopViewModel = SearchShopViewModel()
+    private let searchShopViewModel = SearchShopViewModel(hotPepperAPI: APIClient())
     private let disposeBag = DisposeBag()
     
     override func viewDidLoad() {

--- a/CTAProject/UIComponent/ViewController/SearchShopViewController.swift
+++ b/CTAProject/UIComponent/ViewController/SearchShopViewController.swift
@@ -47,8 +47,8 @@ final class SearchShopViewController: UIViewController {
         
         searchShopViewModel.outputs.shopData
             .bind(to: shopTableView.rx.items(cellIdentifier: ShopTableViewCell.identifier, cellType: ShopTableViewCell.self)) {
-                _, shops, cell in
-                cell.configureCell(shop: shops)
+                _, shop, cell in
+                cell.configureCell(shop: shop)
             }
             .disposed(by: disposeBag)
         

--- a/CTAProject/UILogic/SearchShopViewModel.swift
+++ b/CTAProject/UILogic/SearchShopViewModel.swift
@@ -43,13 +43,13 @@ class SearchShopViewModel: SearchShopViewModelInput, SearchShopViewModelOutput {
     //property
     private let disposeBag = DisposeBag()
     
-    init() {
+    init(hotPepperAPI: HotPepperAPIType) {
         $searchBarSearchButtonClicked
             .filter{1..<50 ~= $0.count}
             .withUnretained(self)
             .subscribe(onNext: { me, searchWord in
                 me.$hudShow.accept(.progress)
-                APIClient.searchShop(searchWord: searchWord, completion: { result in
+                hotPepperAPI.searchShop(searchWord: searchWord, completion: { result in
                     switch result {
                     case .success(let hotpepperResponse):
                         me.$shopData.accept(hotpepperResponse.results.shop)

--- a/CTAProject/UILogic/SearchShopViewModel.swift
+++ b/CTAProject/UILogic/SearchShopViewModel.swift
@@ -1,0 +1,93 @@
+//
+//  SearchShopViewModel.swift
+//  CTAProject
+//
+//  Created by 内山和輝 on 2022/02/24.
+//
+
+//import Foundation
+import RxSwift
+import RxCocoa
+import PKHUD
+import SwiftMessages
+
+protocol SearchShopViewModelInput { // ViewからViewModelに流す用のインターフェース
+    var searchBarSearchButtonClicked: AnyObserver<String>{get}
+    var searchTextInput: AnyObserver<String>{get}
+}
+
+protocol SearchShopViewModelOutput { // Viewへ値を流す用のインターフェース
+    var shopData: Observable<[Shop]>{get}
+    var hudShow: Observable<HUDContentType>{get}
+    var hudHide: Observable<Void>{get}
+    var showPopup: Observable<Void>{get}
+    var showAlert: Observable<Void>{get}
+}
+
+protocol SearchShopViewModelType { //外部で型として使う部分。inputs、outputsとアクセスをわけ、入力と出力を明確にする
+    var inputs: SearchShopViewModelInput {get}
+    var outputs: SearchShopViewModelOutput {get}
+}
+
+class SearchShopViewModel: SearchShopViewModelInput, SearchShopViewModelOutput {
+    
+    //Input
+    @AnyObserverWrapper var searchBarSearchButtonClicked: AnyObserver<String>
+    @AnyObserverWrapper var searchTextInput: AnyObserver<String>
+    //Output
+    @PublishRelayWrapper var shopData: Observable<[Shop]>
+    @PublishRelayWrapper var hudShow: Observable<HUDContentType>
+    @PublishRelayWrapper var hudHide: Observable<Void>
+    @PublishRelayWrapper var showPopup: Observable<Void>
+    @PublishRelayWrapper var showAlert: Observable<Void>
+    //property
+    private let disposeBag = DisposeBag()
+    
+    init() {
+        $searchBarSearchButtonClicked
+            .filter{1..<50 ~= $0.count}
+            .withUnretained(self)
+            .subscribe(onNext: { me, searchWord in
+                me.$hudShow.accept(.progress)
+                APIClient.searchShop(searchWord: searchWord, completion: { result in
+                    switch result {
+                    case .success(let hotpepperResponse):
+                        me.$shopData.accept(hotpepperResponse.results.shop)
+                        me.$hudHide.accept(())
+                        print(hotpepperResponse)
+                    case .failure(let error):
+                        print(error)
+                        me.$hudShow.accept(.progress)
+                    }
+                })
+            })
+            .disposed(by: disposeBag)
+        
+        $hudShow
+            .withUnretained(self)
+            .delay(.seconds(4), scheduler: MainScheduler.instance)
+            .subscribe(onNext: { me, hudContentType in
+                if case .error = hudContentType {
+                    me.$hudHide.accept(())
+                }
+            })
+            .disposed(by: disposeBag)
+        
+        $searchBarSearchButtonClicked
+            .withUnretained(self)
+            .subscribe(onNext: { me, text in
+                print(text)
+                if text.count == 0 {
+                    me.$showPopup.accept(())
+                } else if text.count >= 50 {
+                    me.$showAlert.accept(())
+                }
+            })
+            .disposed(by: disposeBag)
+    }
+}
+
+extension SearchShopViewModel: SearchShopViewModelType {
+    var inputs: SearchShopViewModelInput {return self}
+    var outputs: SearchShopViewModelOutput {return self}
+}

--- a/CTAProject/UILogic/SearchShopViewModel.swift
+++ b/CTAProject/UILogic/SearchShopViewModel.swift
@@ -11,7 +11,7 @@ import PKHUD
 import SwiftMessages
 
 protocol SearchShopViewModelInput { // ViewからViewModelに流す用のインターフェース
-    var searchBarSearchButtonClicked: AnyObserver<String>{get}
+    var searchBarSearchButtonClicked: AnyObserver<Void>{get}
     var searchTextInput: AnyObserver<String>{get}
 }
 
@@ -31,7 +31,7 @@ protocol SearchShopViewModelType { //外部で型として使う部分。inputs�
 class SearchShopViewModel: SearchShopViewModelInput, SearchShopViewModelOutput {
     
     //Input
-    @AnyObserverWrapper var searchBarSearchButtonClicked: AnyObserver<String>
+    @AnyObserverWrapper var searchBarSearchButtonClicked: AnyObserver<Void>
     @AnyObserverWrapper var searchTextInput: AnyObserver<String>
     //Output
     @PublishRelayWrapper var shopData: Observable<[Shop]>
@@ -44,7 +44,8 @@ class SearchShopViewModel: SearchShopViewModelInput, SearchShopViewModelOutput {
     
     init(hotPepperAPI: HotPepperAPIType) {
         $searchBarSearchButtonClicked
-            .filter{1..<50 ~= $0.count}
+            .withLatestFrom($searchTextInput)
+            .filter{ 1..<50 ~= $0.count }
             .withUnretained(self)
             .subscribe(onNext: { me, searchWord in
                 me.$hudShow.accept(.progress)
@@ -73,6 +74,7 @@ class SearchShopViewModel: SearchShopViewModelInput, SearchShopViewModelOutput {
             .disposed(by: disposeBag)
         
         $searchBarSearchButtonClicked
+            .withLatestFrom($searchTextInput)
             .withUnretained(self)
             .subscribe(onNext: { me, searchWord in
                 if searchWord.count == 0 {

--- a/CTAProject/UILogic/SearchShopViewModel.swift
+++ b/CTAProject/UILogic/SearchShopViewModel.swift
@@ -5,7 +5,6 @@
 //  Created by 内山和輝 on 2022/02/24.
 //
 
-//import Foundation
 import RxSwift
 import RxCocoa
 import PKHUD
@@ -25,8 +24,8 @@ protocol SearchShopViewModelOutput { // Viewへ値を流す用のインターフ
 }
 
 protocol SearchShopViewModelType { //外部で型として使う部分。inputs、outputsとアクセスをわけ、入力と出力を明確にする
-    var inputs: SearchShopViewModelInput {get}
-    var outputs: SearchShopViewModelOutput {get}
+    var inputs: SearchShopViewModelInput{get}
+    var outputs: SearchShopViewModelOutput{get}
 }
 
 class SearchShopViewModel: SearchShopViewModelInput, SearchShopViewModelOutput {
@@ -75,11 +74,10 @@ class SearchShopViewModel: SearchShopViewModelInput, SearchShopViewModelOutput {
         
         $searchBarSearchButtonClicked
             .withUnretained(self)
-            .subscribe(onNext: { me, text in
-                print(text)
-                if text.count == 0 {
+            .subscribe(onNext: { me, searchWord in
+                if searchWord.count == 0 {
                     me.$showPopup.accept(())
-                } else if text.count >= 50 {
+                } else if searchWord.count >= 50 {
                     me.$showAlert.accept(())
                 }
             })

--- a/Podfile
+++ b/Podfile
@@ -9,6 +9,11 @@ target 'CTAProject' do
   pod 'Unio'
   pod 'PKHUD'
   pod 'SwiftMessages'
+  pod 'RxCocoa'
+  pod 'RxDataSources'
+  pod 'RealmSwift'
+  pod 'Moya'
+  pod 'SDWebImage'
   # Pods for CTAProject
 
   target 'CTAProjectTests' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,10 +1,31 @@
 PODS:
+  - Alamofire (5.5.0)
+  - Differentiator (5.0.0)
+  - Moya (15.0.0):
+    - Moya/Core (= 15.0.0)
+  - Moya/Core (15.0.0):
+    - Alamofire (~> 5.0)
   - PKHUD (5.3.0)
-  - RxRelay (6.2.0):
-    - RxSwift (= 6.2.0)
-  - RxSwift (6.2.0)
+  - Realm (10.22.0):
+    - Realm/Headers (= 10.22.0)
+  - Realm/Headers (10.22.0)
+  - RealmSwift (10.22.0):
+    - Realm (= 10.22.0)
+  - RxCocoa (6.5.0):
+    - RxRelay (= 6.5.0)
+    - RxSwift (= 6.5.0)
+  - RxDataSources (5.0.0):
+    - Differentiator (~> 5.0)
+    - RxCocoa (~> 6.0)
+    - RxSwift (~> 6.0)
+  - RxRelay (6.5.0):
+    - RxSwift (= 6.5.0)
+  - RxSwift (6.5.0)
+  - SDWebImage (5.12.3):
+    - SDWebImage/Core (= 5.12.3)
+  - SDWebImage/Core (5.12.3)
   - SwiftGen (6.5.1)
-  - SwiftLint (0.45.1)
+  - SwiftLint (0.46.3)
   - SwiftMessages (9.0.6):
     - SwiftMessages/App (= 9.0.6)
   - SwiftMessages/App (9.0.6)
@@ -13,7 +34,12 @@ PODS:
     - RxSwift (~> 6.0)
 
 DEPENDENCIES:
+  - Moya
   - PKHUD
+  - RealmSwift
+  - RxCocoa
+  - RxDataSources
+  - SDWebImage
   - SwiftGen
   - SwiftLint
   - SwiftMessages
@@ -21,23 +47,39 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
+    - Alamofire
+    - Differentiator
+    - Moya
     - PKHUD
+    - Realm
+    - RealmSwift
+    - RxCocoa
+    - RxDataSources
     - RxRelay
     - RxSwift
+    - SDWebImage
     - SwiftGen
     - SwiftLint
     - SwiftMessages
     - Unio
 
 SPEC CHECKSUMS:
+  Alamofire: 1c4fb5369c3fe93d2857c780d8bbe09f06f97e7c
+  Differentiator: e8497ceab83c1b10ca233716d547b9af21b9344d
+  Moya: 138f0573e53411fb3dc17016add0b748dfbd78ee
   PKHUD: 98f3e4bc904b9c916f1c5bb6d765365b5357291b
-  RxRelay: e72dbfd157807478401ef1982e1c61c945c94b2f
-  RxSwift: d356ab7bee873611322f134c5f9ef379fa183d8f
+  Realm: d9e4e5877095a6722145811f56fe89a531c9659d
+  RealmSwift: e4191b4b957fcfcbed23751ec65eec98f8173ab5
+  RxCocoa: 94f817b71c07517321eb4f9ad299112ca8af743b
+  RxDataSources: aa47cc1ed6c500fa0dfecac5c979b723542d79cf
+  RxRelay: 1de1523e604c72b6c68feadedd1af3b1b4d0ecbd
+  RxSwift: 5710a9e6b17f3c3d6e40d6e559b9fa1e813b2ef8
+  SDWebImage: 53179a2dba77246efa8a9b85f5c5b21f8f43e38f
   SwiftGen: a6d22010845f08fe18fbdf3a07a8e380fd22e0ea
-  SwiftLint: 06ac37e4d38c7068e0935bb30cda95f093bec761
+  SwiftLint: ae76d82f056734f853c8cd0371503252c606c482
   SwiftMessages: f0c7ef4705a570ad6c5e208b611f4333e660ed92
   Unio: 6e57bd33dbcf38d281b0b420f75c0eae3bef0cf3
 
-PODFILE CHECKSUM: 191bc69d77092c7c474568bb0c03e906c63edb68
+PODFILE CHECKSUM: 9a84ded4a3cf6483ca9a9202c29d3e01cc99c46e
 
 COCOAPODS: 1.10.2


### PR DESCRIPTION
## 関連URL
[【タスク1】検索機能の実装 ](https://github.com/sosuiiii/CTAProject2022/issues/1)
## 前提
以前のコードをViewModelとViewControllerをRxに書き換えて動くようにしました。
## 仕様
RelayWrapperを追加し、ViewModelのコードを簡易化
Interface対応
## 対応内容
ライブラリのインストール
ViewModel追加、Rxで書く
ViewControllerをRxに書き換え
Interface分離
### 実装機能1
[18851cdb1e464ba8f8638eb08b60d4a4c7931484] ライブラリ導入
[ac78330c53c3d06e78ed18b9e7203924d5b9b35c] ViewModel,ViewControllerのRx対応
[2b332fa69bea83f64b5f455baadf00f77cdd772c] API処理においてインターフェース分離
[5bafa5520681815ee6b4a36a2a232ca584645134] ペアプロで進めていたので中途半端になってしまっていたPopupViewの修正
[2dcf87a4aa23b5060d0b7a197731be75c694d15f] ペアプロの際にとりあえず進んでしまった部分の修正
## レビュー観点
- ViewModel, ViewControllerのRxについての処理についてtips, imo等いただきたいです！
- インジケーターの表示、文字数制限の書き方
## スクリーンショット

|  before  |  after  |
| ---- | ---- |
| ![Simulator Screen Shot - iPhone SE (2nd generation) - 2022-02-05 at 16 34 59](https://user-images.githubusercontent.com/83959618/152633146-5eca35d8-51be-44be-827d-588e25583888.png) | ![Simulator Screen Shot - iPhone SE (2nd generation) - 2022-03-02 at 05 22 34](https://user-images.githubusercontent.com/83959618/156243099-ce1fd99b-55ed-4d7f-880f-b3ee94e4aa9c.png) |

|  popup  |  alert  |
| ---- | ---- |
| ![Simulator Screen Shot - iPhone SE (2nd generation) - 2022-03-02 at 05 24 08](https://user-images.githubusercontent.com/83959618/156243451-87eabebe-e4df-4dc4-a3c9-ba4fbb31b485.png) | ![Simulator Screen Shot - iPhone SE (2nd generation) - 2022-03-02 at 05 24 28](https://user-images.githubusercontent.com/83959618/156243477-5942b277-e239-47ec-ad9b-aeacec47e925.png) |